### PR TITLE
upgrade ghc + stackage will upgrade Data.Text to 2.1.2 having "show"

### DIFF
--- a/gcl/src/Server/Monad.hs
+++ b/gcl/src/Server/Monad.hs
@@ -26,7 +26,7 @@ import Data.IORef
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Proxy
-import Data.Text
+import Data.Text (Text)
 import qualified Data.Text as Text
 import GCL.Predicate (PO, Spec (Specification, specID))
 import GCL.Range (Range, posCol, rangeStart)


### PR DESCRIPTION
The following program will not compile in ghc 9.10.2 + stackge LTS 24.11 .
`Data.Text.show` will conflicts with `Prelude.show`.
SEE: https://github.com/haskell/text/blob/master/changelog.md#212

```
import Data.Text 

main :: IO ()
main = do
    putStrLn $ show (123 :: Int)
```