### PR TITLE
onDidChange: eagerly force list fields (IntervalMaps are already strict via fromAscList)

### DIFF
--- a/gcl/src/Server/Handler/OnDidChangeTextDocument.hs
+++ b/gcl/src/Server/Handler/OnDidChangeTextDocument.hs
@@ -4,12 +4,13 @@
 
 module Server.Handler.OnDidChangeTextDocument where
 
+import Control.Exception (evaluate)
 import Control.Monad.IO.Class (liftIO)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
 import qualified Language.LSP.Protocol.Types as LSP
 import Numeric (showFFloat)
-import Server.Monad (PendingEdit (..), ServerM, deletePendingEdit, getFileState, getPendingEdit, logText, readSource, setFileState)
+import Server.Monad (FileState (..), PendingEdit (..), ServerM, deletePendingEdit, getFileState, getPendingEdit, logText, readSource, setFileState)
 import Server.Move (applyMovesToFileState, mkLSPMoves)
 import Server.Notification.Update (sendUpdateNotification)
 
@@ -37,5 +38,26 @@ handler filePath changes = do
         Nothing -> return ()
         Just fs -> do
           let fs' = applyMovesToFileState (mkLSPMoves changes) fs
+          -- Force all list fields now so the work is done within this handler,
+          -- rather than deferred lazily to the next request.
+          (nToks, nSpecs, nHoles, nPOs, nWarnings) <- liftIO $ do
+            a <- evaluate $ length $ fsSemanticTokens fs'
+            b <- evaluate $ length $ fsSpecifications fs'
+            c <- evaluate $ length $ fsHoles fs'
+            d <- evaluate $ length $ fsProofObligations fs'
+            e <- evaluate $ length $ fsWarnings fs'
+            return (a, b, c, d, e)
+          logText $
+            "tokens: "
+              <> Text.pack (show nToks)
+              <> " specs: "
+              <> Text.pack (show nSpecs)
+              <> " holes: "
+              <> Text.pack (show nHoles)
+              <> " POs: "
+              <> Text.pack (show nPOs)
+              <> " warnings: "
+              <> Text.pack (show nWarnings)
+              <> "\n"
           setFileState filePath fs'
           sendUpdateNotification filePath fs'


### PR DESCRIPTION
希望 onDidChange 時不要 lazy 積欠

List 沒加 "!" 當場算 0 個 (一開始)
List 加 "!" 當場算 1 個 (某次 PR, 但這樣不夠)
List 加 evaluate length 當場算 n 個 (這次的 PR)

Map 在 from List 時全算了, 這次不特別改