### PR TITLE
Add gcl/testVersionedEdit to test VS Code version protection vulnerability

### DIFF
--- a/gcl-vscode/package.json
+++ b/gcl-vscode/package.json
@@ -48,6 +48,11 @@
         "command": "gcl.debug",
         "title": "GCL Debug",
         "category": "GCL"
+      },
+      {
+        "command": "gcl.testVersionedEdit",
+        "title": "Test Versioned Edit",
+        "category": "GCL"
       }
     ],
     "keybindings": [
@@ -65,6 +70,11 @@
         "command": "gcl.debug",
         "key": "ctrl+c ctrl+/",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "gcl.testVersionedEdit",
+        "key": "f11",
+        "when": "editorTextFocus && editorLangId == 'gcl'"
       }
     ],
     "configuration": [

--- a/gcl-vscode/src/extension.ts
+++ b/gcl-vscode/src/extension.ts
@@ -167,6 +167,17 @@ export async function activate(context: vscode.ExtensionContext) {
 		gclPanel.rerender(newClientState);
 	});
 	context.subscriptions.push(errorNotificationHandlerDisposable);
+
+	// Bug testing handler
+	const testHandlerDisposable = vscode.commands.registerCommand('gcl.testVersionedEdit', async () => {
+		const editor = retrieveMainEditor();
+		if (editor && editor.document.languageId === 'gcl') {
+			await sendRequest("gcl/testVersionedEdit", {
+				uri: editor.document.uri.toString(),
+			});
+		}
+	});
+	context.subscriptions.push(testHandlerDisposable);
 }
 
 export async function deactivate() {

--- a/gcl/src/Server/Handler.hs
+++ b/gcl/src/Server/Handler.hs
@@ -33,6 +33,7 @@ import qualified Server.Handler.AutoCompletion as AutoCompletion
 import qualified Server.Handler.GCL.Debug as Debug
 import qualified Server.Handler.GCL.Load as Load
 import qualified Server.Handler.GCL.Refine as Refine
+import qualified Server.Handler.GCL.TestVersionedEdit as TestVersionedEdit
 import qualified Server.Handler.GoToDefinition as GoToDefinition
 import qualified Server.Handler.Hover as Hover
 import qualified Server.Handler.Initialized as Initialized
@@ -118,7 +119,9 @@ handlers =
       -- "gcl/refine" - refine
       requestHandler (LSP.SMethod_CustomMethod (Proxy @"gcl/refine")) $ customRequestMiddleware Refine.handler,
       -- "gcl/debug" - debug FileState
-      requestHandler (LSP.SMethod_CustomMethod (Proxy @"gcl/debug")) $ customRequestMiddleware Debug.handler
+      requestHandler (LSP.SMethod_CustomMethod (Proxy @"gcl/debug")) $ customRequestMiddleware Debug.handler,
+      -- "gcl/testVersionedEdit"
+      requestHandler (LSP.SMethod_CustomMethod (Proxy @"gcl/testVersionedEdit")) $ customRequestMiddleware TestVersionedEdit.handler
     ]
 
 -- Extracts the common boilerplate shared by custom LSP request handlers.

--- a/gcl/src/Server/Handler/GCL/TestVersionedEdit.hs
+++ b/gcl/src/Server/Handler/GCL/TestVersionedEdit.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Server.Handler.GCL.TestVersionedEdit (handler) where
+
+import qualified Data.Aeson as JSON
+import GHC.Generics (Generic)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Server.Monad
+import GCL.Range (mkRange, mkPos)
+import qualified Language.LSP.Protocol.Types as LSP
+
+data Params = Params
+  { uri :: Text
+  } deriving (Generic, JSON.FromJSON)
+
+handler :: Params -> ServerM JSON.Value
+handler (Params uriText) = do
+  let uri = LSP.Uri uriText
+  case LSP.uriToFilePath uri of
+    Nothing -> return JSON.Null
+    Just filePath -> do
+      logTextLn $ "TestVersionedEdit: handling " <> Text.pack filePath
+      maybeSourceAndVersion <- readSourceAndVersion filePath
+      case maybeSourceAndVersion of
+        Nothing -> do
+          logTextLn "TestVersionedEdit: source not found"
+          return JSON.Null
+        Just (source, version) -> do
+          let ls = Text.lines source
+          case ls of
+            [] -> return JSON.Null
+            (firstLine : _) -> do
+              if "apple" `Text.isInfixOf` firstLine
+                then do
+                  logTextLn $ "TestVersionedEdit: apple found in version " <> Text.pack (show version)
+                  -- Replace the first line (1-based line 1, col 1 to col length+1)
+                  let range = mkRange (mkPos 1 1) (mkPos 1 (Text.length firstLine + 1))
+                  sendEditTextsWithVersion filePath version [(range, "ZZZZZ")]
+                  logTextLn "TestVersionedEdit: edit sent"
+                else do
+                  logTextLn $ "TestVersionedEdit: apple NOT found in first line: " <> firstLine
+              return JSON.Null


### PR DESCRIPTION
指定版本編輯 還是有機會在版本跑掉之後仍被編輯
https://www.youtube.com/watch?v=ffjLit9t3Uc