### PR TITLE
Fix hole collection on Load.hs and Refine.hs

### DIFF
--- a/gcl/src/GCL/WP.hs
+++ b/gcl/src/GCL/WP.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 
-module GCL.WP (WP, TM, sweep, structStmts, runWP, collectStmtHoles, collectExprHoles) where
+module GCL.WP (WP, TM, sweep, structStmts, runWP, collectTypedHole) where
 
 import Control.Monad.Except
   ( MonadError (throwError),
@@ -51,7 +51,7 @@ sweep program@(Program _ decs _props stmts _) = do
   (_, counter, (pos, specs, warnings, redexes)) <-
     runWP (structProgram stmts) (decls, dnames) 0
   -- collect holes from expressions
-  let holes = collectProgramHoles program
+  let holes = collectTypedHole program
   -- update Proof Obligations with corresponding Proof Anchors
   let proofAnchors =
         stmts >>= \case
@@ -127,72 +127,70 @@ structStmts = this
     (wpSegs, wpSStmts, wp) = wpFunctions structSegs
     spSStmts = spFunctions (structSegs, struct)
 
-collectProgramHoles :: Program -> [Hole]
-collectProgramHoles (Program defs decls exprs stmts _) =
-  concatMap collectDefHoles defs
-    <> concatMap collectDeclHoles decls
-    <> concatMap collectExprHoles exprs
-    <> concatMap collectStmtHoles stmts
-  where
-    collectDefHoles :: Definition -> [Hole]
-    collectDefHoles (ValDefn _ _ expr) = collectExprHoles expr
-    collectDefHoles _ = []
+-- Hole collection
 
-    collectDeclHoles :: Declaration -> [Hole]
-    collectDeclHoles (ConstDecl _ _ (Just expr) _) = collectExprHoles expr
-    collectDeclHoles (VarDecl _ _ (Just expr) _) = collectExprHoles expr
-    collectDeclHoles _ = []
+class CollectTypedHole a where
+  collectTypedHole :: a -> [Hole]
 
-collectStmtHoles :: Stmt -> [Hole]
-collectStmtHoles (Assign _ exprs _) = concatMap collectExprHoles exprs
-collectStmtHoles (AAssign a b c _) =
-  collectExprHoles a
-    <> collectExprHoles b
-    <> collectExprHoles c
-collectStmtHoles (If guards _) = concatMap collectGdCmdHoles guards
-collectStmtHoles (Do guards _) = concatMap collectGdCmdHoles guards
-collectStmtHoles (Block program _) = collectProgramHoles program
-collectStmtHoles (Alloc _ exprs _) = concatMap collectExprHoles exprs
-collectStmtHoles (HLookup _ expr _) = collectExprHoles expr
-collectStmtHoles (HMutate _ expr _) = collectExprHoles expr
-collectStmtHoles (Dispose expr _) = collectExprHoles expr
-collectStmtHoles _ = []
+instance (CollectTypedHole a) => CollectTypedHole [a] where
+  collectTypedHole = concatMap collectTypedHole
 
-collectGdCmdHoles :: GdCmd -> [Hole]
-collectGdCmdHoles (GdCmd guard body _) =
-  collectExprHoles guard
-    <> concatMap collectStmtHoles body
+instance (CollectTypedHole a) => CollectTypedHole (Maybe a) where
+  collectTypedHole (Just a) = collectTypedHole a
+  collectTypedHole Nothing = mempty
 
-collectExprHoles :: Expr -> [Hole]
-collectExprHoles (Chain ch) = collectChainHoles ch
-  where
-    collectChainHoles :: Chain -> [Hole]
-    collectChainHoles (Pure a) =
-      collectExprHoles a
-    collectChainHoles (More c _ _ a) =
-      collectChainHoles c
-        <> collectExprHoles a
-collectExprHoles (App a b _) =
-  collectExprHoles a
-    <> collectExprHoles b
-collectExprHoles (Lam _ _ a _) =
-  collectExprHoles a
-collectExprHoles (Quant a _ b c _) =
-  collectExprHoles a
-    <> collectExprHoles b
-    <> collectExprHoles c
-collectExprHoles (ArrIdx a b _) =
-  collectExprHoles a
-    <> collectExprHoles b
-collectExprHoles (ArrUpd a b c _) =
-  collectExprHoles a
-    <> collectExprHoles b
-    <> collectExprHoles c
-collectExprHoles (Case a _ _) =
-  collectExprHoles a
-collectExprHoles (Subst a b) =
-  collectExprHoles a
-    <> concatMap (collectExprHoles . snd) b
-collectExprHoles (EHole _ i ty range env) =
-  [Hole i ty range env]
-collectExprHoles _ = []
+instance CollectTypedHole Program where
+  collectTypedHole (Program defs decls exprs stmts _) =
+    collectTypedHole defs <> collectTypedHole decls <> collectTypedHole exprs <> collectTypedHole stmts
+
+instance CollectTypedHole Definition where
+  collectTypedHole (TypeDefn {}) = mempty
+  collectTypedHole (ValDefn _ _ expr) = collectTypedHole expr
+
+instance CollectTypedHole Declaration where
+  collectTypedHole (ConstDecl _ _ expr _) = collectTypedHole expr
+  collectTypedHole (VarDecl _ _ expr _) = collectTypedHole expr
+
+instance CollectTypedHole Stmt where
+  collectTypedHole (Skip {}) = mempty
+  collectTypedHole (Abort {}) = mempty
+  collectTypedHole (Assign _ exprs _) = collectTypedHole exprs
+  collectTypedHole (AAssign a b c _) = collectTypedHole a <> collectTypedHole b <> collectTypedHole c
+  collectTypedHole (Assert expr _) = collectTypedHole expr
+  collectTypedHole (LoopInvariant a b _) = collectTypedHole a <> collectTypedHole b
+  collectTypedHole (Do guards _) = collectTypedHole guards
+  collectTypedHole (If guards _) = collectTypedHole guards
+  collectTypedHole (Spec {}) = mempty
+  collectTypedHole (Proof {}) = mempty
+  collectTypedHole (Alloc _ exprs _) = collectTypedHole exprs
+  collectTypedHole (HLookup _ expr _) = collectTypedHole expr
+  collectTypedHole (HMutate _ expr _) = collectTypedHole expr
+  collectTypedHole (Dispose expr _) = collectTypedHole expr
+  collectTypedHole (Block program _) = collectTypedHole program
+
+instance CollectTypedHole GdCmd where
+  collectTypedHole (GdCmd guard body _) = collectTypedHole guard <> collectTypedHole body
+
+instance CollectTypedHole Expr where
+  collectTypedHole (Lit {}) = mempty
+  collectTypedHole (Var {}) = mempty
+  collectTypedHole (Const {}) = mempty
+  collectTypedHole (Op {}) = mempty
+  collectTypedHole (Chain chain) = collectTypedHole chain
+  collectTypedHole (App a b _) = collectTypedHole a <> collectTypedHole b
+  collectTypedHole (Lam _ _ expr _) = collectTypedHole expr
+  collectTypedHole (Tuple exprs) = collectTypedHole exprs
+  collectTypedHole (OutT _ expr) = collectTypedHole expr
+  collectTypedHole (Quant a _ b c _) = collectTypedHole a <> collectTypedHole b <> collectTypedHole c
+  collectTypedHole (ArrIdx a b _) = collectTypedHole a <> collectTypedHole b
+  collectTypedHole (ArrUpd a b c _) = collectTypedHole a <> collectTypedHole b <> collectTypedHole c
+  collectTypedHole (Case expr clauses _) = collectTypedHole expr <> collectTypedHole clauses
+  collectTypedHole (Subst expr substs) = collectTypedHole expr <> (collectTypedHole . map snd) substs
+  collectTypedHole (EHole _ i ty range env) = [Hole i ty range env]
+
+instance CollectTypedHole CaseClause where
+  collectTypedHole (CaseClause _ expr) = collectTypedHole expr
+
+instance CollectTypedHole Chain where
+  collectTypedHole (Pure expr) = collectTypedHole expr
+  collectTypedHole (More c _ _ expr) = collectTypedHole c <> collectTypedHole expr

--- a/gcl/src/GCL/WP.hs
+++ b/gcl/src/GCL/WP.hs
@@ -140,8 +140,10 @@ instance (CollectTypedHole a) => CollectTypedHole (Maybe a) where
   collectTypedHole Nothing = mempty
 
 instance CollectTypedHole Program where
+  -- Deduplicates the list of holes since declaration might gives duplication result.
   collectTypedHole (Program defs decls exprs stmts _) =
-    collectTypedHole defs <> collectTypedHole decls <> collectTypedHole exprs <> collectTypedHole stmts
+    List.nub $
+      collectTypedHole defs <> collectTypedHole decls <> collectTypedHole exprs <> collectTypedHole stmts
 
 instance CollectTypedHole Definition where
   collectTypedHole (TypeDefn {}) = mempty

--- a/gcl/src/Server/Load.hs
+++ b/gcl/src/Server/Load.hs
@@ -173,15 +173,32 @@ class CollectHole a where
 instance (CollectHole a) => CollectHole [a] where
   collectHole = concatMap collectHole
 
+instance (CollectHole a) => CollectHole (Maybe a) where
+  collectHole (Just a) = collectHole a
+  collectHole Nothing = mempty
+
+instance (CollectHole a, CollectHole b) => CollectHole (Either a b) where
+  collectHole = either collectHole collectHole
+
 instance (CollectHole a) => CollectHole (SepBy s a) where
   collectHole (Head c) = collectHole c
   collectHole (Delim c _ cs) = collectHole c <> collectHole cs
 
 instance CollectHole C.Program where
-  collectHole (C.Program decls stmts) = (collectHole . rights) decls <> collectHole stmts
+  collectHole (C.Program decls stmts) = collectHole decls <> collectHole stmts
 
 instance CollectHole C.DefinitionBlock where
   collectHole (C.DefinitionBlock _ defs _) = collectHole defs
+
+instance CollectHole C.Declaration where
+  collectHole (C.ConstDecl _ decl) = collectHole decl
+  collectHole (C.VarDecl _ decl) = collectHole decl
+
+instance CollectHole C.DeclType where
+  collectHole (C.DeclType _ prop) = collectHole prop
+
+instance CollectHole C.DeclProp where
+  collectHole (C.DeclProp _ expr _) = collectHole expr
 
 instance CollectHole C.Definition where
   collectHole (C.TypeDefn {}) = mempty

--- a/gcl/src/Server/Load.hs
+++ b/gcl/src/Server/Load.hs
@@ -3,6 +3,7 @@
 module Server.Load where
 
 import Data.Bifunctor (first)
+import Data.Either (rights)
 import qualified Data.IntMap as IntMap
 import Data.List (sortBy)
 import Data.Ord (comparing)
@@ -170,15 +171,22 @@ applyEdits source edits =
 class CollectHole a where
   collectHole :: a -> [(HoleKind, Range)]
 
-instance CollectHole C.Program where
-  collectHole (C.Program _ statements) = collectHole statements
-
 instance (CollectHole a) => CollectHole [a] where
   collectHole = concatMap collectHole
 
 instance (CollectHole a) => CollectHole (SepBy s a) where
   collectHole (Head c) = collectHole c
   collectHole (Delim c _ cs) = collectHole c <> collectHole cs
+
+instance CollectHole C.Program where
+  collectHole (C.Program decls stmts) = (collectHole . rights) decls <> collectHole stmts
+
+instance CollectHole C.DefinitionBlock where
+  collectHole (C.DefinitionBlock _ defs _) = collectHole defs
+
+instance CollectHole C.Definition where
+  collectHole (C.ValDefn _ _ _ expr) = collectHole expr
+  collectHole _ = mempty
 
 instance CollectHole C.Stmt where
   collectHole (C.SpecQM range) = [(StmtHole, range)]
@@ -193,7 +201,7 @@ instance CollectHole C.Stmt where
   collectHole (C.HMutate _ a _ b) = collectHole a <> collectHole b
   collectHole (C.Dispose _ a) = collectHole a
   collectHole (C.Block _ program _) = collectHole program
-  collectHole _ = []
+  collectHole _ = mempty
 
 instance CollectHole C.GdCmd where
   collectHole (GdCmd expr _ stmts) = collectHole expr <> collectHole stmts
@@ -206,7 +214,7 @@ instance CollectHole C.Expr where
   collectHole (C.Quant _ _ _ _ a _ b _) = collectHole a <> collectHole b
   collectHole (C.Case _ a _ clauses) = collectHole a <> collectHole clauses
   collectHole (C.Chain chain) = collectHole chain
-  collectHole _ = []
+  collectHole _ = mempty
 
 instance CollectHole C.CaseClause where
   collectHole (C.CaseClause _ _ expr) = collectHole expr

--- a/gcl/src/Server/Load.hs
+++ b/gcl/src/Server/Load.hs
@@ -13,7 +13,6 @@ import Error (Error (..))
 import GCL.Dependency (evalDependencyResolution)
 import GCL.Range (Range, posCol, posLine, rangeEnd, rangeStart)
 import GCL.Type2.ToTyped (runToTyped)
-import GCL.Type2.Types (Inference (..))
 import qualified GCL.WP as WP
 import qualified Hack
 import Server.GoToDefn (collectLocationLinks)
@@ -185,36 +184,44 @@ instance CollectHole C.DefinitionBlock where
   collectHole (C.DefinitionBlock _ defs _) = collectHole defs
 
 instance CollectHole C.Definition where
+  collectHole (C.TypeDefn {}) = mempty
+  collectHole (C.ValDefnSig {}) = mempty
   collectHole (C.ValDefn _ _ _ expr) = collectHole expr
-  collectHole _ = mempty
 
 instance CollectHole C.Stmt where
-  collectHole (C.SpecQM range) = [(StmtHole, range)]
+  collectHole (C.Skip {}) = mempty
+  collectHole (C.Abort {}) = mempty
   collectHole (C.Assign _ _ exprs) = collectHole exprs
   collectHole (C.AAssign _ _ a _ _ b) = collectHole a <> collectHole b
   collectHole (C.Assert _ a _) = collectHole a
   collectHole (C.LoopInvariant _ a _ _ _ b _) = collectHole a <> collectHole b
   collectHole (C.Do _ ss _) = collectHole ss
   collectHole (C.If _ ss _) = collectHole ss
+  collectHole (C.SpecQM range) = [(StmtHole, range)]
+  collectHole (C.Spec {}) = mempty
+  collectHole (C.Proof {}) = mempty
   collectHole (C.Alloc _ _ _ _ es _) = collectHole es
   collectHole (C.HLookup _ _ _ a) = collectHole a
   collectHole (C.HMutate _ a _ b) = collectHole a <> collectHole b
   collectHole (C.Dispose _ a) = collectHole a
   collectHole (C.Block _ program _) = collectHole program
-  collectHole _ = mempty
 
 instance CollectHole C.GdCmd where
   collectHole (GdCmd expr _ stmts) = collectHole expr <> collectHole stmts
 
 instance CollectHole C.Expr where
-  collectHole (C.HoleQM range) = [(ExprHole, range)]
   collectHole (C.Paren _ expr _) = collectHole expr
+  collectHole (C.Lit {}) = mempty
+  collectHole (C.Var {}) = mempty
+  collectHole (C.Const {}) = mempty
+  collectHole (C.Op {}) = mempty
+  collectHole (C.Chain chain) = collectHole chain
   collectHole (C.Arr a _ b _) = collectHole a <> collectHole b
   collectHole (C.App a b) = collectHole a <> collectHole b
   collectHole (C.Quant _ _ _ _ a _ b _) = collectHole a <> collectHole b
   collectHole (C.Case _ a _ clauses) = collectHole a <> collectHole clauses
-  collectHole (C.Chain chain) = collectHole chain
-  collectHole _ = mempty
+  collectHole (C.HoleQM range) = [(ExprHole, range)]
+  collectHole (C.Hole {}) = mempty
 
 instance CollectHole C.CaseClause where
   collectHole (C.CaseClause _ _ expr) = collectHole expr

--- a/gcl/src/Server/Refine.hs
+++ b/gcl/src/Server/Refine.hs
@@ -15,7 +15,7 @@ import GCL.Range (Pos (..), R (..), Range (..), extractText, mkPos, mkRange, ran
 import GCL.Type2.Infer (typeCheck')
 import GCL.Type2.ToTyped (runToTyped)
 import GCL.Type2.Types (Env, Inference, runTI)
-import GCL.WP (runWP, structStmts, collectTypedHole)
+import GCL.WP (collectTypedHole, runWP, structStmts)
 import GCL.WP.Types (StructError, StructWarning (..))
 import qualified Hack
 import Language.Lexer.Applicative (TokenStream (..))

--- a/gcl/src/Server/Refine.hs
+++ b/gcl/src/Server/Refine.hs
@@ -15,7 +15,7 @@ import GCL.Range (Pos (..), R (..), Range (..), extractText, mkPos, mkRange, ran
 import GCL.Type2.Infer (typeCheck')
 import GCL.Type2.ToTyped (runToTyped)
 import GCL.Type2.Types (Env, Inference, runTI)
-import GCL.WP (collectExprHoles, collectStmtHoles, runWP, structStmts)
+import GCL.WP (runWP, structStmts, collectTypedHole)
 import GCL.WP.Types (StructError, StructWarning (..))
 import qualified Hack
 import Language.Lexer.Applicative (TokenStream (..))
@@ -103,7 +103,7 @@ refine filePath cursor = do
                   setPendingEdit filePath pending
                 Right (typedExpr, state) -> do
                   let (holes1, holes2) = splitAtFirst hole (fsHoles fs)
-                      newHoles = justifyExpHoleRanges $ collectExprHoles typedExpr
+                      newHoles = justifyExpHoleRanges $ collectTypedHole typedExpr
                       holes2' = justifyRearHoleRanges (length newHoles - 1) (holeRange hole) holes2
                       newFs =
                         movedFs
@@ -277,7 +277,7 @@ sweepFragment :: Int -> Spec -> [T.Stmt] -> Either StructError ([PO], [Spec], [H
 sweepFragment counter (Specification _ pre post _ _) impl =
   second
     ( \(_, counter', (pos, specs, sws, _redexes)) ->
-        (pos, specs, concatMap collectStmtHoles impl, sws, counter')
+        (pos, specs, collectTypedHole impl, sws, counter')
     )
     $ runWP
       (structStmts Primary (pre, Nothing) impl post)


### PR DESCRIPTION
Previously, multiple locations where hole digging is possible are either:
1. Not diggable, for example, in the definition block / declaration prop:
```agda
con A, B : Int { ? } -- Previously not diggable

{:
  truth : Bool
  truth = ? -- Previously not diggable
:}
```
2. Not refine-able, as seen in #124, for example, expression in assertion and various other locations:
```agda
{ {! ? = ? !} } -- Previously not refine-able
```

In this patch, by introducing typeclasses `CollectHole` and `CollectTypedHole`, and forcing every cases to be exhaustive without using wildcard, this reduces the error-prone situation where additional syntax being added but hole collection missed the case.

Fix #124.